### PR TITLE
Add special "instance or subclass" mode

### DIFF
--- a/src/lib/force-graph/graph-data.ts
+++ b/src/lib/force-graph/graph-data.ts
@@ -114,7 +114,8 @@ export class SparqlGraphData {
 
 		for (const line of lines) {
 			const sourceId = line.item?.value;
-			const targetId = line.linkTo?.value ?? line.altLinkTo?.value;
+			const targetId = line.linkTo?.value;
+			const linkType = line.linkType?.value
 
 			if (!sourceId || !nodesMap.has(sourceId) || !targetId || !nodesMap.has(targetId)) {
 				continue;
@@ -126,7 +127,7 @@ export class SparqlGraphData {
 				target: nodesMap.get(targetId)!,
 				isShortcut: false,
 				indexColor: '',
-				dashed: Boolean(!line.linkTo?.value && line.altLinkTo?.value),
+				dashed: linkType === 'instance',
 			};
 			link.indexColor = this.colorTracker.register({type: 'Link', object: link} as SearchObject)!;
 

--- a/src/lib/force-graph/graph-data.ts
+++ b/src/lib/force-graph/graph-data.ts
@@ -114,7 +114,7 @@ export class SparqlGraphData {
 
 		for (const line of lines) {
 			const sourceId = line.item?.value;
-			const targetId = line.linkTo?.value;
+			const targetId = line.linkTo?.value ?? line.altLinkTo?.value;
 
 			if (!sourceId || !nodesMap.has(sourceId) || !targetId || !nodesMap.has(targetId)) {
 				continue;
@@ -126,6 +126,7 @@ export class SparqlGraphData {
 				target: nodesMap.get(targetId)!,
 				isShortcut: false,
 				indexColor: '',
+				dashed: Boolean(!line.linkTo?.value && line.altLinkTo?.value),
 			};
 			link.indexColor = this.colorTracker.register({type: 'Link', object: link} as SearchObject)!;
 

--- a/src/lib/force-graph/types.d.ts
+++ b/src/lib/force-graph/types.d.ts
@@ -54,6 +54,7 @@ export type LinkObject = {
 	source: NodeObject;
 	target: NodeObject;
 	isShortcut: boolean;
+	dashed?: boolean;
 	label?: string;
 	sections?: Array<[number, number]>;
 	indexColor: string;

--- a/src/routes/About.svelte
+++ b/src/routes/About.svelte
@@ -83,6 +83,20 @@ SERVICE wikibase:label {bd:serviceParam wikibase:language "en" }
             mode: "reverse",
             size_property: "P106",
         },
+        "Class tree for Statue of Liberty": {
+            property: "P31",
+            item: "Q9202",
+            mode: "forward",
+            graph_direction: "down",
+            instance_or_subclass: "1",
+        },
+        "Classification of finite simple groups": {
+            property: "P31",
+            item: "Q45033382",
+            mode: "reverse",
+            graph_direction: "down",
+            instance_or_subclass: "1",
+        },
     };
 </script>
 

--- a/src/routes/QueryForm.svelte
+++ b/src/routes/QueryForm.svelte
@@ -9,6 +9,7 @@
     import NumberInput from "$lib/components/common/NumberInput.svelte";
     import Select from "$lib/components/common/Select.svelte";
     import Button from "$lib/components/common/Button.svelte";
+    import Checkbox from "$lib/components/common/Checkbox.svelte";
     import Field from "$lib/components/common/Field.svelte";
     import ItemEdit from "$lib/components/wikidata/ItemEdit.svelte";
     import ButtonsBox from "$lib/components/common/ButtonsBox.svelte";
@@ -37,6 +38,17 @@
     let wdqs: string | undefined;
     let sizeProperty: string | undefined;
     let sizePropertyObject: ValueItem | undefined;
+    let instanceOrSubclass = false;
+
+    $: if (property !== "P31") {
+        instanceOrSubclass = false;
+    }
+
+    $: if (instanceOrSubclass) {
+        iterations = undefined;
+        sizeProperty = undefined;
+        sizePropertyObject = undefined;
+    }
 
     const dispatch = createEventDispatcher();
 
@@ -53,6 +65,8 @@
             wdqs,
             sizeProperty,
         } = appParameters.queryParameters);
+        instanceOrSubclass =
+            appParameters.queryParameters.special?.instanceOrSubclass ?? false;
 
         // https://github.com/sveltejs/svelte/issues/4470
         // await tick();
@@ -68,6 +82,9 @@
         mode,
         wdqs,
         sizeProperty: sizePropertyObject?.id,
+        special: {
+            instanceOrSubclass,
+        },
     } as QueryParameters;
 
     $: isValid = queryParametersIsValid(formQueryParameters);
@@ -107,6 +124,13 @@
             />
         </Field>
 
+        {#if property === "P31"}
+            <Checkbox
+                label="Instance or subclass"
+                bind:value={instanceOrSubclass}
+            />
+        {/if}
+
         <Field label="Root item">
             <ItemEdit
                 bind:value={item}
@@ -116,24 +140,26 @@
             />
         </Field>
 
-        <Field label="Iterations">
-            <NumberInput
-                bind:value={iterations}
-                min={0}
-                max={100000}
-                placeholder="Unlimited"
-                treatZeroAsUndefined={true}
-            />
-        </Field>
+        {#if !instanceOrSubclass}
+            <Field label="Iterations">
+                <NumberInput
+                    bind:value={iterations}
+                    min={0}
+                    max={100000}
+                    placeholder="Unlimited"
+                    treatZeroAsUndefined={true}
+                />
+            </Field>
 
-        <Field label="Size property">
-            <ItemEdit
-                bind:value={sizeProperty}
-                bind:valueObject={sizePropertyObject}
-                type="property"
-                {language}
-            />
-        </Field>
+            <Field label="Size property">
+                <ItemEdit
+                    bind:value={sizeProperty}
+                    bind:valueObject={sizePropertyObject}
+                    type="property"
+                    {language}
+                />
+            </Field>
+        {/if}
     {/if}
 
     <ButtonsBox class="flex gap-2 pt-2">

--- a/src/routes/app.ts
+++ b/src/routes/app.ts
@@ -55,6 +55,7 @@ export const parseUrlParameters = (parameters: URLSearchParams = new URLSearchPa
 	const limit = /^\d+$/.test(parameters.get('limit') ?? '')
 		? Number.parseInt(parameters.get('limit')!, 10)
 		: defaultLimit;
+	const instanceOrSubclass = parameters.get('instance_or_subclass') === '1';
 
 	const modeRaw = parameters.get('mode') ?? parameters.get('direction');
 	const mode
@@ -65,7 +66,7 @@ export const parseUrlParameters = (parameters: URLSearchParams = new URLSearchPa
 		: undefined;
 
 	const queryParameters: QueryParameters = {
-		property, item, language, iterations, limit, mode, wdqs, sizeProperty,
+		property, item, language, iterations, limit, mode, wdqs, sizeProperty, special: {instanceOrSubclass},
 	};
 
 	const shortcutsModeRaw = parameters.get('sc') as ShortcutsMode;
@@ -141,6 +142,10 @@ export const updateUrl = async (query: QueryParameters, vis: VisParameters, repl
 
 	if (vis.graphDirection !== defaultGraphLayout) {
 		parameters.append('graph_direction', vis.graphDirection);
+	}
+
+	if (query.special?.instanceOrSubclass) {
+		parameters.append('instance_or_subclass', '1');
 	}
 
 	await goto('?' + parameters.toString(), {replaceState});

--- a/src/routes/sparql-gen.ts
+++ b/src/routes/sparql-gen.ts
@@ -81,7 +81,7 @@ export const generateQuery = (options: QueryParameters | undefined) => {
 			clauses.push(`\
 				{
 					BIND(wd:${options.item} AS ?item)
-					OPTIONAL { ?item wdt:P31 ?altLinkTo }
+					OPTIONAL { ?item wdt:P31 ?linkTo BIND("instance" AS ?linkType) }
 				}
 				UNION
 				{
@@ -107,13 +107,13 @@ export const generateQuery = (options: QueryParameters | undefined) => {
 				{
 					?class wdt:P279* wd:${options.item} .
 					?item wdt:P31 ?class .
-					OPTIONAL { ?item wdt:P31 ?altLinkTo }
+					OPTIONAL { ?item wdt:P31 ?linkTo BIND("instance" AS ?linkType) }
 				}\
 				`);
 		}
 
 		return `\
-			SELECT DISTINCT ?item ?itemLabel ?linkTo ?altLinkTo {
+			SELECT DISTINCT ?item ?itemLabel ?linkTo ?linkType {
 				${clauses.join('\nUNION\n')}
 				${languageService}
 			}\


### PR DESCRIPTION
Fixes #13

When the traversal property is set to "instance of", a checkbox appears that changes the behavior from traversing the property "instance of" (which is rarely useful) to traversing superclasses of direct superclasses in the forward direction, and traversing subclasses to direct instances in the reverse direction (instances are connected with dashed lines to distinguish them from subclasses). Bidirectional mode is supported, though undirected isn't–right now the graph simply crashes–and neither are maximum iterations and the size property. I've also made some pretty invasive changes to the code to make this feature easier to implement, so all in all I don't think this should be merged in the current state, but I'm sharing it for anyone who might find it useful, and I'd be more than happy to implement suggestions that would make this fit for merging.