### PR TITLE
Add support for default labels

### DIFF
--- a/src/routes/sparql-gen.ts
+++ b/src/routes/sparql-gen.ts
@@ -68,7 +68,7 @@ export const generateQuery = (options: QueryParameters | undefined) => {
 	}
 
 	const out = useGas(options) ? 'PREFIX gas: <http://www.bigdata.com/rdf/gas#>\n\n' : '';
-	const language = options.language === 'en' ? 'en' : (options.language + ',en');
+	const language = options.language === 'en' ? 'en,mul' : (options.language + ',mul,en');
 	const languageService = `SERVICE wikibase:label {bd:serviceParam wikibase:language "${language}" }`;
 
 	if (options.sizeProperty) {


### PR DESCRIPTION
Wikidata now supports [default labels](https://www.wikidata.org/wiki/Help:Default_values_for_labels_and_aliases), which means items whose name is the same across many languages don't need to have identical labels in these languages anymore.